### PR TITLE
chore: Adds lint checks to CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,3 +35,18 @@ jobs:
 
       - name: Unit tests
         run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          version: latest
+          args: -v --config ./.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -218,19 +218,16 @@ linters-settings:
 
 linters:
   enable:
-    - gofmt
+    # - gofmt
     - govet
-    - errcheck
-    - staticcheck
-    - unused
-    - gosimple
-    - structcheck
-    - varcheck
+    # - errcheck
+    # - staticcheck
+    # - unused
+    # - gosimple
     - ineffassign
-    - deadcode
     - typecheck
     # Additional
-    - lll
+    # - lll
     - godox
     #- gomnd
     #- goconst
@@ -239,10 +236,10 @@ linters:
     # - nestif
     # - gomodguard
     - nakedret
-    - gci
+    # - gci
     - misspell
-    - gofumpt
-    - whitespace
+    # - gofumpt
+    # - whitespace
     - unconvert
     - predeclared
     - noctx


### PR DESCRIPTION
# Description

There was a .golangci.yml file for linting validation but it was not used in the CI. This PR adds golang lint validation in the github actions set of validations. I commented out the checks that failed. Those will be addressed carefully one at the time in future PR's as they will require some code changes. At least now we will have some linting validation. I also removed the deprecated lint checks like deadcode.
