### PR TITLE
chore: Enables gofmt linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -218,7 +218,7 @@ linters-settings:
 
 linters:
   enable:
-    # - gofmt
+    - gofmt
     - govet
     # - errcheck
     # - staticcheck

--- a/producer/network_slice_information_document.go
+++ b/producer/network_slice_information_document.go
@@ -85,7 +85,8 @@ func parseQueryParameter(query url.Values) (plugin.NsselectionQueryParameter, er
 
 // Check if the NF service consumer is authorized
 // TODO: Check if the NF service consumer is legal with local configuration, or possibly after querying NRF through
-//       `nf-id` e.g. Whether the V-NSSF is authorized
+//
+//	`nf-id` e.g. Whether the V-NSSF is authorized
 func checkNfServiceConsumer(nfType models.NfType) error {
 	if nfType != models.NfType_AMF && nfType != models.NfType_NSSF {
 		return fmt.Errorf("`nf-type`:'%s' is not authorized to retrieve the slice selection information", string(nfType))


### PR DESCRIPTION
# Description

This PR enables the go fmt lint check and makes the necessary change to satisfy it.
