### PR TITLE
chore: Move http_wrapper dependency to util project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/omec-project/config5g v1.2.0
 	github.com/omec-project/http2_util v1.1.0
-	github.com/omec-project/http_wrapper v1.1.0
 	github.com/omec-project/logger_util v1.1.0
 	github.com/omec-project/openapi v1.1.0
 	github.com/omec-project/path_util v1.1.0
+	github.com/omec-project/util v1.0.12
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.14
 	gopkg.in/yaml.v2 v2.4.0
@@ -20,7 +20,7 @@ require (
 
 require (
 	github.com/antihax/optional v1.0.0 // indirect
-	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,9 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/antonfisher/nested-logrus-formatter v1.3.0/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
 github.com/antonfisher/nested-logrus-formatter v1.3.1 h1:NFJIr+pzwv5QLHTPyKz9UMEoHck02Q9L0FP13b/xSbQ=
 github.com/antonfisher/nested-logrus-formatter v1.3.1/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
-github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
@@ -193,8 +194,6 @@ github.com/omec-project/config5g v1.2.0 h1:fyIg+1LZ9jn8DTkVUbD4jyxA4FgMICdIBwZVn
 github.com/omec-project/config5g v1.2.0/go.mod h1:AWFzCbbgCBx/iJwt+zWbpDGLHRpFzg24OYHqIkdcMVA=
 github.com/omec-project/http2_util v1.1.0 h1:8H2NME/V8iONth8TlyK/3w4pguAzaeUnEv9pmeAocwQ=
 github.com/omec-project/http2_util v1.1.0/go.mod h1:QwoZRaUyhEp/kTEqXvf0gCYtfQrNHBdkVw939vsMjZY=
-github.com/omec-project/http_wrapper v1.1.0 h1:2hD8RUaR/VVg3tUUfuxsuo1/JNpZLiAE8IvATGqDME4=
-github.com/omec-project/http_wrapper v1.1.0/go.mod h1:mc045fjVVJ0/q0g4QG4nuSC0N1BIqGR/ZoK76XgifVU=
 github.com/omec-project/logger_conf v1.1.0 h1:C0/HbsSOWV8D3/lm7Iqe1nUL9ltVtVO4MDC9ZxIo/xc=
 github.com/omec-project/logger_conf v1.1.0/go.mod h1:2+SOX9OFbPZ+UNv8k+tvPnaWHo4CuX5G/x12dz5sWUE=
 github.com/omec-project/logger_util v1.1.0 h1:R7tT80+ML1HlK4OoTrNv/UK+2H/u2GdIFNBx41g630Q=
@@ -203,6 +202,8 @@ github.com/omec-project/openapi v1.1.0 h1:N3v59+FM2V/eCv2Au10kbyeTf1DsScJkEdkDEc
 github.com/omec-project/openapi v1.1.0/go.mod h1:Fv9ajWROYypcNER+ZwWXPhLCdV4pBz75KqFp/R/2gCw=
 github.com/omec-project/path_util v1.1.0 h1:vzzLsay8+uexyYEqS06th8lMcwp+N+CXcaHhaypZn1Q=
 github.com/omec-project/path_util v1.1.0/go.mod h1:O1ch35al6+FXKmg6+5vOpKusl4fiB0u36oYjxwI4QK4=
+github.com/omec-project/util v1.0.12 h1:fmeeUxexHdi4nipAJumaq4lcx9l83FPaNfGH2fRmTTw=
+github.com/omec-project/util v1.0.12/go.mod h1:Cn9P57qYFiEu0ZXti8imODsJIXVGqnqhP40MwbVbo3g=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/nssaiavailability/api_nf_instance_id_document.go
+++ b/nssaiavailability/api_nf_instance_id_document.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/nssf/plugin"
 	"github.com/omec-project/nssf/producer"
@@ -28,7 +28,7 @@ import (
 )
 
 func HTTPNSSAIAvailabilityDelete(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["nfId"] = c.Params.ByName("nfId")
 
 	rsp := producer.HandleNSSAIAvailabilityDelete(req)
@@ -76,7 +76,7 @@ func HTTPNSSAIAvailabilityPatch(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, nssaiAvailabilityUpdateInfo)
+	req := httpwrapper.NewRequest(c.Request, nssaiAvailabilityUpdateInfo)
 	req.Params["nfId"] = c.Params.ByName("nfId")
 
 	rsp := producer.HandleNSSAIAvailabilityPatch(req)
@@ -124,7 +124,7 @@ func HTTPNSSAIAvailabilityPut(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, nssaiAvailabilityInfo)
+	req := httpwrapper.NewRequest(c.Request, nssaiAvailabilityInfo)
 	req.Params["nfId"] = c.Params.ByName("nfId")
 
 	rsp := producer.HandleNSSAIAvailabilityPut(req)

--- a/nssaiavailability/api_subscription_id_document.go
+++ b/nssaiavailability/api_subscription_id_document.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/nssf/producer"
 	"github.com/omec-project/openapi"
@@ -35,7 +35,7 @@ func HTTPNSSAIAvailabilityUnsubscribe(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["subscriptionId"] = c.Params.ByName("subscriptionId")
 
 	rsp := producer.HandleNSSAIAvailabilityUnsubscribe(req)

--- a/nssaiavailability/api_subscriptions_collection.go
+++ b/nssaiavailability/api_subscriptions_collection.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/nssf/producer"
 	"github.com/omec-project/openapi"
@@ -55,7 +55,7 @@ func HTTPNSSAIAvailabilityPost(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, createData)
+	req := httpwrapper.NewRequest(c.Request, createData)
 
 	rsp := producer.HandleNSSAIAvailabilityPost(req)
 

--- a/nsselection/api_network_slice_information_document.go
+++ b/nsselection/api_network_slice_information_document.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/nssf/producer"
 	"github.com/omec-project/openapi"
@@ -27,7 +27,7 @@ import (
 )
 
 func HTTPNetworkSliceInformationDocument(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 
 	rsp := producer.HandleNSSelectionGet(req)
 

--- a/producer/network_slice_information_document.go
+++ b/producer/network_slice_information_document.go
@@ -21,11 +21,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/nssf/plugin"
 	"github.com/omec-project/nssf/util"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // Parse NSSelectionGet query parameter
@@ -94,7 +94,7 @@ func checkNfServiceConsumer(nfType models.NfType) error {
 }
 
 // NSSelectionGet - Retrieve the Network Slice Selection Information
-func HandleNSSelectionGet(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleNSSelectionGet(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Nsselection.Infof("Handle NSSelectionGet")
 
 	query := request.Query
@@ -102,15 +102,15 @@ func HandleNSSelectionGet(request *http_wrapper.Request) *http_wrapper.Response 
 	response, problemDetails := NSSelectionGetProcedure(query)
 
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func NSSelectionGetProcedure(query url.Values) (*models.AuthorizedNetworkSliceInfo, *models.ProblemDetails) {

--- a/producer/nf_instance_id_document.go
+++ b/producer/nf_instance_id_document.go
@@ -17,15 +17,15 @@ package producer
 import (
 	"net/http"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/nssf/plugin"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // HandleNSSAIAvailabilityDelete - Deletes an already existing S-NSSAIs per TA
 // provided by the NF service consumer (e.g AMF)
-func HandleNSSAIAvailabilityDelete(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleNSSAIAvailabilityDelete(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Nssaiavailability.Infof("Handle NSSAIAvailabilityDelete")
 
 	nfID := request.Params["nfId"]
@@ -33,14 +33,14 @@ func HandleNSSAIAvailabilityDelete(request *http_wrapper.Request) *http_wrapper.
 	problemDetails := NSSAIAvailabilityDeleteProcedure(nfID)
 
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
-	return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
 // HandleNSSAIAvailabilityPatch - Updates an already existing S-NSSAIs per TA
 // provided by the NF service consumer (e.g AMF)
-func HandleNSSAIAvailabilityPatch(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleNSSAIAvailabilityPatch(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Nssaiavailability.Infof("Handle NSSAIAvailabilityPatch")
 
 	nssaiAvailabilityUpdateInfo := request.Body.(plugin.PatchDocument)
@@ -54,20 +54,20 @@ func HandleNSSAIAvailabilityPatch(request *http_wrapper.Request) *http_wrapper.R
 	response, problemDetails := NSSAIAvailabilityPatchProcedure(nssaiAvailabilityUpdateInfo, nfID)
 
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 // HandleNSSAIAvailabilityPut - Updates/replaces the NSSF
 // with the S-NSSAIs the NF service consumer (e.g AMF) supports per TA
-func HandleNSSAIAvailabilityPut(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleNSSAIAvailabilityPut(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Nssaiavailability.Infof("Handle NSSAIAvailabilityPut")
 
 	nssaiAvailabilityInfo := request.Body.(models.NssaiAvailabilityInfo)
@@ -76,13 +76,13 @@ func HandleNSSAIAvailabilityPut(request *http_wrapper.Request) *http_wrapper.Res
 	response, problemDetails := NSSAIAvailabilityPutProcedure(nssaiAvailabilityInfo, nfID)
 
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }

--- a/producer/subscription_id_document.go
+++ b/producer/subscription_id_document.go
@@ -17,14 +17,14 @@ package producer
 import (
 	"net/http"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 	"reflect"
 )
 
 // HandleNSSAIAvailabilityUnsubscribe - Deletes an already existing NSSAI availability notification subscription
-func HandleNSSAIAvailabilityUnsubscribe(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleNSSAIAvailabilityUnsubscribe(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Nssaiavailability.Infof("Handle NSSAIAvailabilityUnsubscribe")
 
 	subscriptionID := request.Params["subscriptionId"]
@@ -32,13 +32,13 @@ func HandleNSSAIAvailabilityUnsubscribe(request *http_wrapper.Request) *http_wra
 	problemDetails := NSSAIAvailabilityUnsubscribeProcedure(subscriptionID)
 
 	if problemDetails == nil {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	} else if reflect.DeepEqual(*problemDetails, models.ProblemDetails{}) {
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusForbidden,
 			Cause:  "UNSPECIFIED",
 		}
-		return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+		return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 	}
-	return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+	return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 }

--- a/producer/subscriptions_collection.go
+++ b/producer/subscriptions_collection.go
@@ -17,13 +17,13 @@ package producer
 import (
 	"net/http"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // HandleNSSAIAvailabilityPost - Creates subscriptions for notification about updates to NSSAI availability information
-func HandleNSSAIAvailabilityPost(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleNSSAIAvailabilityPost(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.Nssaiavailability.Infof("Handle NSSAIAvailabilityPost")
 
 	createData := request.Body.(models.NssfEventSubscriptionCreateData)
@@ -34,13 +34,13 @@ func HandleNSSAIAvailabilityPost(request *http_wrapper.Request) *http_wrapper.Re
 
 	if response != nil {
 		// TODO: Based on TS 29.531 5.3.2.3.1, add location header
-		return http_wrapper.NewResponse(http.StatusCreated, nil, response)
+		return httpwrapper.NewResponse(http.StatusCreated, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }


### PR DESCRIPTION
Moves the `http_wrapper` dependency to the `util` project. Tested with a successful `gnbsim` simulation.