### PR TITLE
chore: Parameterise webui URL

### DIFF
--- a/factory/config.go
+++ b/factory/config.go
@@ -46,6 +46,7 @@ type Configuration struct {
 	Sbi                      *Sbi                    `yaml:"sbi"`
 	ServiceNameList          []models.ServiceName    `yaml:"serviceNameList"`
 	NrfUri                   string                  `yaml:"nrfUri"`
+	WebuiUri                 string                  `yaml:"webuiUri"`
 	SupportedPlmnList        []models.PlmnId         `yaml:"supportedPlmnList,omitempty"`
 	SupportedNssaiInPlmnList []SupportedNssaiInPlmn  `yaml:"supportedNssaiInPlmnList"`
 	NsiList                  []NsiConfig             `yaml:"nsiList,omitempty"`

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -41,11 +41,13 @@ func InitConfigFactory(f string) error {
 		if yamlErr := yaml.Unmarshal(content, &NssfConfig); yamlErr != nil {
 			return yamlErr
 		}
-
+		if NssfConfig.Configuration.WebuiUri == "" {
+			NssfConfig.Configuration.WebuiUri = "webui:9876"
+		}
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			logger.CfgLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-			commChannel := client.ConfigWatcher()
+			commChannel := client.ConfigWatcher(NssfConfig.Configuration.WebuiUri)
 			go NssfConfig.updateConfig(commChannel)
 		} else {
 			go func() {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/uuid v1.6.0
-	github.com/omec-project/config5g v1.3.0
+	github.com/omec-project/config5g v1.3.1
 	github.com/omec-project/http2_util v1.2.0
 	github.com/omec-project/logger_util v1.2.0
 	github.com/omec-project/openapi v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
-github.com/omec-project/config5g v1.3.0 h1:e/oMZlQsef8bOpHT56uAMKIag3epCOW0jpmyadFC+30=
-github.com/omec-project/config5g v1.3.0/go.mod h1:h6eaDdWEY7432L9rZAg1Za6HrvFvDWRNolAn5GK/5No=
+github.com/omec-project/config5g v1.3.1 h1:hSvFHXh/J0mslsWR82PPnmpF0WzkmLa6AOdvEPve9e8=
+github.com/omec-project/config5g v1.3.1/go.mod h1:lN/Jc2BZkE/smOGPCXxeo1dJ7s+s9Wgp34crNLH4YeE=
 github.com/omec-project/http2_util v1.2.0 h1:ggQ1GjY2x6VRpKuRhZj0t9dh6eISY6LRBv4rlMD++8s=
 github.com/omec-project/http2_util v1.2.0/go.mod h1:KLgvU3o7qmG/i5XO/qITscFql2tWCAmjE6glX+dxe7M=
 github.com/omec-project/logger_conf v1.1.1 h1:qo0cF5gnPfth8wy+I/QjiOx+F5jB6h4GLSOdyS+ted8=

--- a/test/conf/test_nssf_config.yaml
+++ b/test/conf/test_nssf_config.yaml
@@ -17,6 +17,7 @@ configuration:
     - nnssf_nsselection
     - nnssf_nssaiavailability
   nrfUri: https://localhost:29510
+  webuiUri: webui:9876
   supportedPlmnList:
     - mcc: 466
       mnc: 92


### PR DESCRIPTION
Config5g library was including the hard coded Webui URL in ConfigWatcher function which is used by several NFs.
PR: https://github.com/omec-project/config5g/pull/35 in Config5G  library allows to change weburi URL. 
Based on that change [this PR](https://github.com/omec-project/nssf/pull/70) provides to pass the Weburi URL in NSSF. 

Note: https://github.com/omec-project/config5g/pull/35 should be merged before this PR.
