### PR TITLE
feat: parametrize paths for TLS certificate and private key

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/omec-project/nssf/factory"
 	"github.com/omec-project/nssf/logger"
+	"github.com/omec-project/nssf/util"
 	"github.com/omec-project/openapi/models"
 )
 
@@ -53,6 +54,8 @@ type NSSFContext struct {
 	UriScheme         models.UriScheme
 	RegisterIPv4      string
 	BindingIPv4       string
+	Key               string
+	PEM               string
 	NfService         map[models.ServiceName]models.NfService
 	NrfUri            string
 	SupportedPlmnList []models.PlmnId
@@ -75,6 +78,16 @@ func InitNssfContext() {
 	nssfContext.RegisterIPv4 = nssfConfig.Configuration.Sbi.RegisterIPv4
 	nssfContext.SBIPort = nssfConfig.Configuration.Sbi.Port
 	nssfContext.BindingIPv4 = os.Getenv(nssfConfig.Configuration.Sbi.BindingIPv4)
+	nssfContext.Key = util.NSSF_KEY_PATH // default key path
+	nssfContext.PEM = util.NSSF_PEM_PATH // default PEM path
+	if tls := nssfConfig.Configuration.Sbi.TLS; tls != nil {
+		if tls.Key != "" {
+			nssfContext.Key = tls.Key
+		}
+		if tls.PEM != "" {
+			nssfContext.PEM = tls.PEM
+		}
+	}
 	if nssfContext.BindingIPv4 != "" {
 		logger.ContextLog.Info("Parsing ServerIPv4 address from ENV Variable.")
 	} else {

--- a/factory/config.go
+++ b/factory/config.go
@@ -58,11 +58,17 @@ type Configuration struct {
 
 type Sbi struct {
 	Scheme models.UriScheme `yaml:"scheme"`
+	TLS    *TLS             `yaml:"tls"`
 	// Currently only support IPv4 and thus `Ipv4Addr` field shall not be empty
 	RegisterIPv4 string `yaml:"registerIPv4,omitempty"` // IP that is registered at NRF.
 	// IPv6Addr string `yaml:"ipv6Addr,omitempty"`
 	BindingIPv4 string `yaml:"bindingIPv4,omitempty"` // IP used to run the server in the node.
 	Port        int    `yaml:"port"`
+}
+
+type TLS struct {
+	PEM string `yaml:"pem,omitempty"`
+	Key string `yaml:"key,omitempty"`
 }
 
 type AmfConfig struct {

--- a/service/init.go
+++ b/service/init.go
@@ -192,7 +192,7 @@ func (nssf *NSSF) Start() {
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(util.NSSF_PEM_PATH, util.NSSF_KEY_PATH)
+		err = server.ListenAndServeTLS(self.PEM, self.Key)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR adds a `tls` container, composed of `pem` and `key` keys, inside `sbi` container to specify the paths of TLS certificate and private key to use for the HTTPS server.
If the `tls` container is not specified, or `key` or `pem` are not specified, the values are defaulted to maintain backward compatibility.