### PR TITLE
chore: enable staticcheck and govet in the CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,16 +21,15 @@ linters:
     - goconst
     - godox
     - gomodguard
+    - govet
     - misspell
     - nakedret
     - noctx
     - predeclared
+    - staticcheck
     - unconvert
     - unparam
     - whitespace
-  disable:
-    - govet
-    - staticcheck
   settings:
     errcheck:
       check-type-assertions: false
@@ -64,6 +63,8 @@ linters:
         - XXX
     govet:
       enable-all: true
+      disable:
+        - fieldalignment
       settings:
         printf:
           funcs:

--- a/factory/config.go
+++ b/factory/config.go
@@ -146,7 +146,7 @@ func (c *Config) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) boo
 					logger.GrpcLog.Infoln("Slice Sst ", ns.Nssai.Sst)
 					logger.GrpcLog.Infoln("Slice Sd ", ns.Nssai.Sd)
 					sNssaiInPlmns.SupportedSnssaiList = append(sNssaiInPlmns.SupportedSnssaiList, *nssai)
-					var found bool = false
+					found := false
 					for _, cplmn := range NssfConfig.Configuration.SupportedPlmnList {
 						if (cplmn.Mnc == plmn.Mnc) && (cplmn.Mcc == plmn.Mcc) {
 							found = true

--- a/producer/nssaiavailability_store.go
+++ b/producer/nssaiavailability_store.go
@@ -51,7 +51,7 @@ func NSSAIAvailabilityPatchProcedure(nssaiAvailabilityUpdateInfo plugin.PatchDoc
 	*models.AuthorizedNssaiAvailabilityInfo, *models.ProblemDetails,
 ) {
 	var (
-		response       *models.AuthorizedNssaiAvailabilityInfo = &models.AuthorizedNssaiAvailabilityInfo{}
+		response       = &models.AuthorizedNssaiAvailabilityInfo{}
 		problemDetails *models.ProblemDetails
 	)
 
@@ -160,7 +160,7 @@ func NSSAIAvailabilityPutProcedure(nssaiAvailabilityInfo models.NssaiAvailabilit
 	*models.AuthorizedNssaiAvailabilityInfo, *models.ProblemDetails,
 ) {
 	var (
-		response       *models.AuthorizedNssaiAvailabilityInfo = &models.AuthorizedNssaiAvailabilityInfo{}
+		response       = &models.AuthorizedNssaiAvailabilityInfo{}
 		problemDetails *models.ProblemDetails
 	)
 

--- a/producer/nssaiavailability_subscription.go
+++ b/producer/nssaiavailability_subscription.go
@@ -52,7 +52,7 @@ func NSSAIAvailabilityPostProcedure(createData models.NssfEventSubscriptionCreat
 	*models.NssfEventSubscriptionCreatedData, *models.ProblemDetails,
 ) {
 	var (
-		response       *models.NssfEventSubscriptionCreatedData = &models.NssfEventSubscriptionCreatedData{}
+		response       = &models.NssfEventSubscriptionCreatedData{}
 		problemDetails *models.ProblemDetails
 	)
 

--- a/producer/nsselection_for_registration.go
+++ b/producer/nsselection_for_registration.go
@@ -77,7 +77,7 @@ func useDefaultSubscribedSnssai(
 			// Default Access Type is set to 3GPP Access if no TAI is provided
 			// TODO: Depend on operator implementation, it may also return S-NSSAIs in all valid Access Type if
 			//       UE's Access Type could not be identified
-			var accessType models.AccessType = models.AccessType__3_GPP_ACCESS
+			accessType := models.AccessType__3_GPP_ACCESS
 			if param.Tai != nil {
 				accessType = util.GetAccessTypeFromConfig(*param.Tai)
 			}
@@ -237,7 +237,7 @@ func nsselectionForRegistration(param plugin.NsselectionQueryParameter,
 					// Default Access Type is set to 3GPP Access if no TAI is provided
 					// TODO: Depend on operator implementation, it may also return S-NSSAIs in all valid Access Type if
 					//       UE's Access Type could not be identified
-					var accessType models.AccessType = models.AccessType__3_GPP_ACCESS
+					accessType := models.AccessType__3_GPP_ACCESS
 					if param.Tai != nil {
 						accessType = util.GetAccessTypeFromConfig(*param.Tai)
 					}
@@ -270,7 +270,7 @@ func nsselectionForRegistration(param plugin.NsselectionQueryParameter,
 					// Default Access Type is set to 3GPP Access if no TAI is provided
 					// TODO: Depend on operator implementation, it may also return S-NSSAIs in all valid Access Type if
 					//       UE's Access Type could not be identified
-					var accessType models.AccessType = models.AccessType__3_GPP_ACCESS
+					accessType := models.AccessType__3_GPP_ACCESS
 					if param.Tai != nil {
 						accessType = util.GetAccessTypeFromConfig(*param.Tai)
 					}
@@ -369,7 +369,7 @@ func nsselectionForRegistration(param plugin.NsselectionQueryParameter,
 					// Default Access Type is set to 3GPP Access if no TAI is provided
 					// TODO: Depend on operator implementation, it may also return S-NSSAIs in all valid Access Type if
 					//       UE's Access Type could not be identified
-					var accessType models.AccessType = models.AccessType__3_GPP_ACCESS
+					accessType := models.AccessType__3_GPP_ACCESS
 					if param.Tai != nil {
 						accessType = util.GetAccessTypeFromConfig(*param.Tai)
 					}

--- a/service/init.go
+++ b/service/init.go
@@ -234,6 +234,9 @@ func (nssf *NSSF) Start() {
 		err = server.ListenAndServe()
 	case "https":
 		err = server.ListenAndServeTLS(self.PEM, self.Key)
+	default:
+		logger.InitLog.Fatalf("HTTP server setup failed: server scheme %+v not recognized", serverScheme)
+		return
 	}
 
 	if err != nil {

--- a/service/init.go
+++ b/service/init.go
@@ -235,7 +235,7 @@ func (nssf *NSSF) Start() {
 	case "https":
 		err = server.ListenAndServeTLS(self.PEM, self.Key)
 	default:
-		logger.InitLog.Fatalf("HTTP server setup failed: server scheme %+v not recognized", serverScheme)
+		logger.InitLog.Fatalf("HTTP server setup failed: invalid server scheme %+v", serverScheme)
 		return
 	}
 

--- a/service/init.go
+++ b/service/init.go
@@ -229,9 +229,10 @@ func (nssf *NSSF) Start() {
 	}
 
 	serverScheme := factory.NssfConfig.Configuration.Sbi.Scheme
-	if serverScheme == "http" {
+	switch serverScheme {
+	case "http":
 		err = server.ListenAndServe()
-	} else if serverScheme == "https" {
+	case "https":
 		err = server.ListenAndServeTLS(self.PEM, self.Key)
 	}
 


### PR DESCRIPTION
this PR enables `staticcheck` and `govet` in the CI
- fix variable declaration
- replace if with switch
- fieldaligment remains disabled