### PR TITLE
fix: response in NSSelectionGetProcedure

### DIFF
--- a/producer/network_slice_information_document.go
+++ b/producer/network_slice_information_document.go
@@ -165,11 +165,10 @@ func NSSelectionGetProcedure(query url.Values) (*models.AuthorizedNetworkSliceIn
 		status = nsselectionForPduSession(param, response, problemDetails)
 	}
 
-	if status == http.StatusOK {
-		return response, nil
-	} else {
+	if status != http.StatusOK {
 		return nil, problemDetails
 	}
+	return response, nil
 }
 
 func GetNfTypeFromQueryParameters(query url.Values) (nfType string) {


### PR DESCRIPTION
When making requests to the NSSF /nnssf-nsselection/v1/network-slice-information endpoint using not supported S-NSSAI, the NSSF returns a 200 OK response. This is not correct 

This is due to an incorrect return value. Which is fixed in this PR.
This PR fixes https://github.com/omec-project/nssf/issues/208

Response after this fix:
```
{"title":"Unsupported request resources","status":403,"detail":"S-NSSAI in Requested NSSAI is not supported in PLMN","cause":"SNSSAI_NOT_SUPPORTED"}
```