### PR TITLE
NSSF API does not support /v2 in URI

### DIFF
--- a/nsselection/routers.go
+++ b/nsselection/routers.go
@@ -46,7 +46,7 @@ func NewRouter() *gin.Engine {
 }
 
 func AddService(engine *gin.Engine) *gin.RouterGroup {
-	group := engine.Group("/nnssf-nsselection/v1")
+	group := engine.Group("/nnssf-nsselection/v2")
 
 	for _, route := range routes {
 		switch route.Method {


### PR DESCRIPTION
Issue/Feature Description:
When testing HTTP/2 N22 interface message HTTPV2_NNSSF_NETWORK_SLICE_SELECTION_GET_REQ from AMF → NSSF, the request uses the following path (with v2 in URI as defined in 3GPP TS 29.531):
:method = GET
:path = /127.0.0.1:12348/nnssf-nsselection/v2/network-slice-information?nf-type=AMF&nf-id=5a2b84e4-0cb7-4575-ac08-46a2812bec0d&slice-info-request-for-registration={"requestedNssai":[{"sst":1}],"subscribedNssai":[{"subscribedSnssai":{"sst":1},"defaultIndication":true}]}&tai={"plmnId":{"mcc":"208","mnc":"93"},"tac":"0x000001"}&home-plmn-id={"mcc":"208","mnc":"93"}

However, on NSSF, the request is received/validated with /v1 support: (V2 support is not validated)
:path = /127.0.0.1:12348/nnssf-nsselection/v1/network-slice-information?...

As per spec, it should be strictly V2

Spec ref: https://www.etsi.org/deliver/etsi_ts/129500_129599/129531/17.04.00_60/ts_129531v170400p.pdf#page=19