### PR TITLE
Use accessors (new, get, set) instead of direct field access

### DIFF
--- a/producer/network_slice_information_document.go
+++ b/producer/network_slice_information_document.go
@@ -38,24 +38,33 @@ func hasExplodedQueryParam(query url.Values, prefix string) bool {
 	return false
 }
 
-func parseExplodedSnssai(query url.Values, prefix string) (models.Snssai, bool, error) {
+func parseSnssaiValues(sst, sd string) (models.Snssai, bool, error) {
 	var snssai models.Snssai
-	var found bool
 
-	if sst := query.Get(prefix + "[sst]"); sst != "" {
-		sstValue, err := strconv.ParseInt(sst, 10, 32)
-		if err != nil {
-			return snssai, false, err
+	if sst == "" {
+		if sd != "" {
+			return snssai, false, fmt.Errorf("missing sst for snssai")
 		}
-		snssai.SetSst(int32(sstValue))
-		found = true
-	}
-	if sd := query.Get(prefix + "[sd]"); sd != "" {
-		snssai.SetSd(sd)
-		found = true
+		return snssai, false, nil
 	}
 
-	return snssai, found, nil
+	sstValue, err := strconv.ParseInt(sst, 10, 32)
+	if err != nil {
+		return snssai, false, err
+	}
+	snssai.SetSst(int32(sstValue))
+
+	if sd != "" {
+		snssai.SetSd(sd)
+	}
+
+	return snssai, true, nil
+}
+
+func parseExplodedSnssai(query url.Values, prefix string) (models.Snssai, bool, error) {
+	sst := query.Get(prefix + "[sst]")
+	sd := query.Get(prefix + "[sd]")
+	return parseSnssaiValues(sst, sd)
 }
 
 func parseExplodedBool(query url.Values, key string) (*bool, error) {
@@ -71,36 +80,60 @@ func parseExplodedBool(query url.Values, key string) (*bool, error) {
 }
 
 func parseExplodedSnssaiList(query url.Values, prefix string) ([]models.Snssai, error) {
-	sstValues := query[prefix+"[sst]"]
-	sdValues := query[prefix+"[sd]"]
-	count := max(len(sstValues), len(sdValues))
-	if count == 0 {
+	indexedItems, present, err := parseExplodedSnssaiEntries(query, prefix)
+	if err != nil {
+		return nil, err
+	}
+	if len(indexedItems) == 0 {
 		return nil, nil
 	}
 
-	items := make([]models.Snssai, 0, count)
-	for i := range count {
-		var item models.Snssai
-		var found bool
-
-		if i < len(sstValues) && sstValues[i] != "" {
-			sstValue, err := strconv.ParseInt(sstValues[i], 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			item.SetSst(int32(sstValue))
-			found = true
-		}
-		if i < len(sdValues) && sdValues[i] != "" {
-			item.SetSd(sdValues[i])
-			found = true
-		}
-		if found {
-			items = append(items, item)
+	items := make([]models.Snssai, 0, len(indexedItems))
+	for i := range indexedItems {
+		if present[i] {
+			items = append(items, indexedItems[i])
 		}
 	}
 
 	return items, nil
+}
+
+func parseExplodedSnssaiEntries(query url.Values, prefix string) ([]models.Snssai, []bool, error) {
+	sstValues := query[prefix+"[sst]"]
+	sdValues := query[prefix+"[sd]"]
+	count := max(len(sstValues), len(sdValues))
+	if count == 0 {
+		return nil, nil, nil
+	}
+
+	items := make([]models.Snssai, count)
+	present := make([]bool, count)
+	for i := range count {
+		var sst string
+		if i < len(sstValues) {
+			sst = sstValues[i]
+		}
+		var sd string
+		if i < len(sdValues) {
+			sd = sdValues[i]
+		}
+
+		item, found, err := parseSnssaiValues(sst, sd)
+		if err != nil {
+			if sst == "" && sd != "" {
+				return nil, nil, fmt.Errorf("missing sst for snssai at index %d", i)
+			}
+			return nil, nil, err
+		}
+		if !found {
+			continue
+		}
+
+		items[i] = item
+		present[i] = true
+	}
+
+	return items, present, nil
 }
 
 func parseExplodedSubscribedSnssaiList(query url.Values, prefix string) ([]models.SubscribedSnssai, error) {
@@ -148,11 +181,11 @@ func parseExplodedSubscribedSnssaiList(query url.Values, prefix string) ([]model
 }
 
 func parseExplodedMappingOfSnssaiList(query url.Values, prefix string) ([]models.MappingOfSnssai, error) {
-	servingSnssai, err := parseExplodedSnssaiList(query, prefix+"[servingSnssai]")
+	servingSnssai, servingPresent, err := parseExplodedSnssaiEntries(query, prefix+"[servingSnssai]")
 	if err != nil {
 		return nil, err
 	}
-	homeSnssai, err := parseExplodedSnssaiList(query, prefix+"[homeSnssai]")
+	homeSnssai, homePresent, err := parseExplodedSnssaiEntries(query, prefix+"[homeSnssai]")
 	if err != nil {
 		return nil, err
 	}
@@ -166,12 +199,12 @@ func parseExplodedMappingOfSnssaiList(query url.Values, prefix string) ([]models
 		var item models.MappingOfSnssai
 		var found bool
 
-		if i < len(servingSnssai) {
-			item.ServingSnssai = servingSnssai[i]
+		if i < len(servingPresent) && servingPresent[i] {
+			item.SetServingSnssai(servingSnssai[i])
 			found = true
 		}
-		if i < len(homeSnssai) {
-			item.HomeSnssai = homeSnssai[i]
+		if i < len(homePresent) && homePresent[i] {
+			item.SetHomeSnssai(homeSnssai[i])
 			found = true
 		}
 		if found {
@@ -236,47 +269,47 @@ func parseQueryParameter(query url.Values) (NsselectionQueryParameter, error) {
 		if subscribedNssai, parseErr := parseExplodedSubscribedSnssaiList(query, "slice-info-request-for-registration[subscribedNssai]"); parseErr != nil {
 			return param, parseErr
 		} else if len(subscribedNssai) != 0 {
-			param.SliceInfoRequestForRegistration.SubscribedNssai = subscribedNssai
+			param.SliceInfoRequestForRegistration.SetSubscribedNssai(subscribedNssai)
 		}
 		if sNssaiForMapping, parseErr := parseExplodedSnssaiList(query, "slice-info-request-for-registration[sNssaiForMapping]"); parseErr != nil {
 			return param, parseErr
 		} else if len(sNssaiForMapping) != 0 {
-			param.SliceInfoRequestForRegistration.SNssaiForMapping = sNssaiForMapping
+			param.SliceInfoRequestForRegistration.SetSNssaiForMapping(sNssaiForMapping)
 		}
 		if requestedNssai, parseErr := parseExplodedSnssaiList(query, "slice-info-request-for-registration[requestedNssai]"); parseErr != nil {
 			return param, parseErr
 		} else if len(requestedNssai) != 0 {
-			param.SliceInfoRequestForRegistration.RequestedNssai = requestedNssai
+			param.SliceInfoRequestForRegistration.SetRequestedNssai(requestedNssai)
 		}
 		if mappingOfNssai, parseErr := parseExplodedMappingOfSnssaiList(query, "slice-info-request-for-registration[mappingOfNssai]"); parseErr != nil {
 			return param, parseErr
 		} else if len(mappingOfNssai) != 0 {
-			param.SliceInfoRequestForRegistration.MappingOfNssai = mappingOfNssai
+			param.SliceInfoRequestForRegistration.SetMappingOfNssai(mappingOfNssai)
 		}
 		if defaultConfiguredSnssaiInd, parseErr := parseExplodedBool(query, "slice-info-request-for-registration[defaultConfiguredSnssaiInd]"); parseErr != nil {
 			return param, parseErr
 		} else if defaultConfiguredSnssaiInd != nil {
-			param.SliceInfoRequestForRegistration.DefaultConfiguredSnssaiInd = defaultConfiguredSnssaiInd
+			param.SliceInfoRequestForRegistration.SetDefaultConfiguredSnssaiInd(*defaultConfiguredSnssaiInd)
 		}
 		if requestMapping, parseErr := parseExplodedBool(query, "slice-info-request-for-registration[requestMapping]"); parseErr != nil {
 			return param, parseErr
 		} else if requestMapping != nil {
-			param.SliceInfoRequestForRegistration.RequestMapping = requestMapping
+			param.SliceInfoRequestForRegistration.SetRequestMapping(*requestMapping)
 		}
 		if ueSupNssrgInd, parseErr := parseExplodedBool(query, "slice-info-request-for-registration[ueSupNssrgInd]"); parseErr != nil {
 			return param, parseErr
 		} else if ueSupNssrgInd != nil {
-			param.SliceInfoRequestForRegistration.UeSupNssrgInd = ueSupNssrgInd
+			param.SliceInfoRequestForRegistration.SetUeSupNssrgInd(*ueSupNssrgInd)
 		}
 		if suppressNssrgInd, parseErr := parseExplodedBool(query, "slice-info-request-for-registration[suppressNssrgInd]"); parseErr != nil {
 			return param, parseErr
 		} else if suppressNssrgInd != nil {
-			param.SliceInfoRequestForRegistration.SuppressNssrgInd = suppressNssrgInd
+			param.SliceInfoRequestForRegistration.SetSuppressNssrgInd(*suppressNssrgInd)
 		}
 		if nsagSupported, parseErr := parseExplodedBool(query, "slice-info-request-for-registration[nsagSupported]"); parseErr != nil {
 			return param, parseErr
 		} else if nsagSupported != nil {
-			param.SliceInfoRequestForRegistration.NsagSupported = nsagSupported
+			param.SliceInfoRequestForRegistration.SetNsagSupported(*nsagSupported)
 		}
 	}
 
@@ -292,15 +325,15 @@ func parseQueryParameter(query url.Values) (NsselectionQueryParameter, error) {
 		if snssai, found, parseErr := parseExplodedSnssai(query, "slice-info-request-for-pdu-session[sNssai]"); parseErr != nil {
 			return param, parseErr
 		} else if found {
-			param.SliceInfoRequestForPduSession.SNssai = snssai
+			param.SliceInfoRequestForPduSession.SetSNssai(snssai)
 		}
 		if roamingIndication := query.Get("slice-info-request-for-pdu-session[roamingIndication]"); roamingIndication != "" {
-			param.SliceInfoRequestForPduSession.RoamingIndication = models.RoamingIndication(roamingIndication)
+			param.SliceInfoRequestForPduSession.SetRoamingIndication(models.RoamingIndication(roamingIndication))
 		}
 		if homeSnssai, found, parseErr := parseExplodedSnssai(query, "slice-info-request-for-pdu-session[homeSnssai]"); parseErr != nil {
 			return param, parseErr
 		} else if found {
-			param.SliceInfoRequestForPduSession.HomeSnssai = &homeSnssai
+			param.SliceInfoRequestForPduSession.SetHomeSnssai(homeSnssai)
 		}
 	}
 

--- a/producer/network_slice_information_document.go
+++ b/producer/network_slice_information_document.go
@@ -64,7 +64,11 @@ func parseSnssaiValues(sst, sd string) (models.Snssai, bool, error) {
 func parseExplodedSnssai(query url.Values, prefix string) (models.Snssai, bool, error) {
 	sst := query.Get(prefix + "[sst]")
 	sd := query.Get(prefix + "[sd]")
-	return parseSnssaiValues(sst, sd)
+	snssai, found, err := parseSnssaiValues(sst, sd)
+	if err != nil && sst == "" && sd != "" {
+		return snssai, false, fmt.Errorf("missing sst for %s", prefix)
+	}
+	return snssai, found, err
 }
 
 func parseExplodedBool(query url.Values, key string) (*bool, error) {
@@ -121,7 +125,7 @@ func parseExplodedSnssaiEntries(query url.Values, prefix string) ([]models.Snssa
 		item, found, err := parseSnssaiValues(sst, sd)
 		if err != nil {
 			if sst == "" && sd != "" {
-				return nil, nil, fmt.Errorf("missing sst for snssai at index %d", i)
+				return nil, nil, fmt.Errorf("missing sst for %s at index %d", prefix, i)
 			}
 			return nil, nil, err
 		}

--- a/producer/network_slice_information_document_test.go
+++ b/producer/network_slice_information_document_test.go
@@ -14,16 +14,13 @@ import (
 
 func TestParseQueryParameterSupportsExplodedRegistrationRequest(t *testing.T) {
 	expectedSliceInfo := models.NewSliceInfoForRegistration()
-	expectedSliceInfo.SubscribedNssai = []models.SubscribedSnssai{{
-		SubscribedSnssai:  models.Snssai{Sst: 1, Sd: openapi.PtrString("010203")},
-		DefaultIndication: openapi.PtrBool(true),
-	}}
-	expectedSliceInfo.RequestedNssai = []models.Snssai{{Sst: 1, Sd: openapi.PtrString("112233")}}
-	expectedSliceInfo.MappingOfNssai = []models.MappingOfSnssai{{
-		ServingSnssai: models.Snssai{Sst: 1, Sd: openapi.PtrString("112233")},
-		HomeSnssai:    models.Snssai{Sst: 2, Sd: openapi.PtrString("445566")},
-	}}
-	expectedSliceInfo.RequestMapping = openapi.PtrBool(true)
+	subscribedSnssai := models.NewSubscribedSnssai(models.Snssai{Sst: 1, Sd: openapi.PtrString("010203")})
+	subscribedSnssai.SetDefaultIndication(true)
+	expectedSliceInfo.SetSubscribedNssai([]models.SubscribedSnssai{*subscribedSnssai})
+	expectedSliceInfo.SetRequestedNssai([]models.Snssai{{Sst: 1, Sd: openapi.PtrString("112233")}})
+	mappingOfSnssai := models.NewMappingOfSnssai(models.Snssai{Sst: 1, Sd: openapi.PtrString("112233")}, models.Snssai{Sst: 2, Sd: openapi.PtrString("445566")})
+	expectedSliceInfo.SetMappingOfNssai([]models.MappingOfSnssai{*mappingOfSnssai})
+	expectedSliceInfo.SetRequestMapping(true)
 
 	expectedHomePlmnID := models.NewPlmnId("001", "01")
 	expectedTai := models.NewTai(*expectedHomePlmnID, "000001")
@@ -59,5 +56,56 @@ func TestParseQueryParameterSupportsExplodedRegistrationRequest(t *testing.T) {
 	}
 	if !reflect.DeepEqual(param.Tai, expectedTai) {
 		t.Fatalf("unexpected tai: %+v", param.Tai)
+	}
+}
+
+func TestParseExplodedMappingOfSnssaiListPreservesIndexes(t *testing.T) {
+	query := url.Values{
+		"mappingOfNssai[servingSnssai][sst]": {"", "1"},
+		"mappingOfNssai[homeSnssai][sst]":    {"2", "3"},
+	}
+
+	mappingOfNssai, err := parseExplodedMappingOfSnssaiList(query, "mappingOfNssai")
+	if err != nil {
+		t.Fatalf("parseExplodedMappingOfSnssaiList returned error: %v", err)
+	}
+
+	expected := []models.MappingOfSnssai{
+		{
+			HomeSnssai: models.Snssai{Sst: 2},
+		},
+		{
+			ServingSnssai: models.Snssai{Sst: 1},
+			HomeSnssai:    models.Snssai{Sst: 3},
+		},
+	}
+
+	if !reflect.DeepEqual(mappingOfNssai, expected) {
+		t.Fatalf("unexpected mappingOfNssai: %+v", mappingOfNssai)
+	}
+}
+
+func TestParseExplodedSnssaiListRejectsSdWithoutSst(t *testing.T) {
+	query := url.Values{
+		"requestedNssai[sd]": {"010203"},
+	}
+
+	_, err := parseExplodedSnssaiList(query, "requestedNssai")
+	if err == nil {
+		t.Fatal("expected error for sd without sst")
+	}
+}
+
+func TestParseExplodedSnssaiRejectsSdWithoutSst(t *testing.T) {
+	query := url.Values{
+		"sNssai[sd]": {"010203"},
+	}
+
+	_, found, err := parseExplodedSnssai(query, "sNssai")
+	if err == nil {
+		t.Fatal("expected error for sd without sst")
+	}
+	if found {
+		t.Fatal("expected snssai not to be marked found on invalid input")
 	}
 }

--- a/producer/network_slice_information_document_test.go
+++ b/producer/network_slice_information_document_test.go
@@ -6,6 +6,7 @@ package producer
 import (
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/omec-project/openapi/v2"
@@ -94,6 +95,9 @@ func TestParseExplodedSnssaiListRejectsSdWithoutSst(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for sd without sst")
 	}
+	if !strings.Contains(err.Error(), "requestedNssai") {
+		t.Fatalf("expected error to include parameter name, got %q", err)
+	}
 }
 
 func TestParseExplodedSnssaiRejectsSdWithoutSst(t *testing.T) {
@@ -107,5 +111,8 @@ func TestParseExplodedSnssaiRejectsSdWithoutSst(t *testing.T) {
 	}
 	if found {
 		t.Fatal("expected snssai not to be marked found on invalid input")
+	}
+	if !strings.Contains(err.Error(), "sNssai") {
+		t.Fatalf("expected error to include parameter name, got %q", err)
 	}
 }

--- a/producer/nssaiavailability_subscription.go
+++ b/producer/nssaiavailability_subscription.go
@@ -16,7 +16,6 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/omec-project/nssf/factory"
 	"github.com/omec-project/nssf/logger"
@@ -68,12 +67,12 @@ func NSSAIAvailabilityPostProcedure(createData models.NssfEventSubscriptionCreat
 
 	factory.NssfConfig.Subscriptions = append(factory.NssfConfig.Subscriptions, subscription)
 
-	response.SubscriptionId = subscription.SubscriptionId
-	if !subscription.SubscriptionData.Expiry.IsZero() {
-		response.Expiry = new(time.Time)
-		*response.Expiry = *subscription.SubscriptionData.Expiry
+	response.SetSubscriptionId(subscription.SubscriptionId)
+	timeExpiry := subscription.SubscriptionData.GetExpiry()
+	if !timeExpiry.IsZero() {
+		response.SetExpiry(timeExpiry)
 	}
-	response.AuthorizedNssaiAvailabilityData = util.AuthorizeOfTaListFromConfig(subscription.SubscriptionData.TaiList)
+	response.SetAuthorizedNssaiAvailabilityData(util.AuthorizeOfTaListFromConfig(subscription.SubscriptionData.GetTaiList()))
 
 	return response, nil
 }

--- a/producer/nsselection_for_pdu_session.go
+++ b/producer/nsselection_for_pdu_session.go
@@ -17,7 +17,6 @@ import (
 	"net/http"
 
 	"github.com/omec-project/nssf/util"
-	"github.com/omec-project/openapi/v2"
 	"github.com/omec-project/openapi/v2/models"
 	"github.com/omec-project/openapi/v2/utils"
 )
@@ -41,7 +40,8 @@ func nsselectionForPduSession(param NsselectionQueryParameter,
 	if param.HomePlmnId != nil {
 		// Check whether UE's Home PLMN is supported when UE is a roamer
 		if !util.CheckSupportedHplmn(*param.HomePlmnId) {
-			authorizedNetworkSliceInfo.RejectedNssaiInPlmn = append(authorizedNetworkSliceInfo.RejectedNssaiInPlmn, param.SliceInfoRequestForPduSession.SNssai)
+			rejectedNssaiInPlmn := append(authorizedNetworkSliceInfo.GetRejectedNssaiInPlmn(), param.SliceInfoRequestForPduSession.GetSNssai())
+			authorizedNetworkSliceInfo.SetRejectedNssaiInPlmn(rejectedNssaiInPlmn)
 
 			status = http.StatusOK
 			return status
@@ -51,7 +51,8 @@ func nsselectionForPduSession(param NsselectionQueryParameter,
 	if param.Tai != nil {
 		// Check whether UE's current TA is supported when UE provides TAI
 		if !util.CheckSupportedTa(*param.Tai) {
-			authorizedNetworkSliceInfo.RejectedNssaiInTa = append(authorizedNetworkSliceInfo.RejectedNssaiInTa, param.SliceInfoRequestForPduSession.SNssai)
+			rejectedNssaiInTa := append(authorizedNetworkSliceInfo.GetRejectedNssaiInTa(), param.SliceInfoRequestForPduSession.GetSNssai())
+			authorizedNetworkSliceInfo.SetRejectedNssaiInTa(rejectedNssaiInTa)
 
 			status = http.StatusOK
 			return status
@@ -59,7 +60,7 @@ func nsselectionForPduSession(param NsselectionQueryParameter,
 	}
 
 	if param.Tai != nil &&
-		!util.CheckSupportedSnssaiInPlmn(param.SliceInfoRequestForPduSession.SNssai, param.Tai.PlmnId) {
+		!util.CheckSupportedSnssaiInPlmn(param.SliceInfoRequestForPduSession.GetSNssai(), param.Tai.GetPlmnId()) {
 		// Return ProblemDetails indicating S-NSSAI is not supported
 		// TODO: Based on TS 23.501 V15.2.0, if the Requested NSSAI includes an S-NSSAI that is not valid in the
 		//       Serving PLMN, the NSSF may derive the Configured NSSAI for Serving PLMN
@@ -74,43 +75,38 @@ func nsselectionForPduSession(param NsselectionQueryParameter,
 	}
 
 	if param.HomePlmnId != nil {
-		if param.SliceInfoRequestForPduSession.RoamingIndication == models.ROAMINGINDICATION_NON_ROAMING {
+		if param.SliceInfoRequestForPduSession.GetRoamingIndication() == models.ROAMINGINDICATION_NON_ROAMING {
 			problemDetail := "`home-plmn-id` is provided, which contradicts `roamingIndication`:'NON_ROAMING'"
-			invalidParams := []models.InvalidParam{
-				{
-					Param:  "home-plmn-id",
-					Reason: openapi.PtrString(problemDetail),
-				},
-			}
+			invalidParam := models.NewInvalidParam("home-plmn-id")
+			invalidParam.SetReason(problemDetail)
+			invalidParams := []models.InvalidParam{*invalidParam}
 			*problemDetails = *utils.ProblemDetailsWithInvalidParams(util.INVALID_REQUEST, http.StatusBadRequest, problemDetail, invalidParams)
 			status = http.StatusBadRequest
 			return status
 		}
 	} else {
-		if param.SliceInfoRequestForPduSession.RoamingIndication != models.ROAMINGINDICATION_NON_ROAMING {
+		if param.SliceInfoRequestForPduSession.GetRoamingIndication() != models.ROAMINGINDICATION_NON_ROAMING {
 			problemDetail := fmt.Sprintf("`home-plmn-id` is not provided, which contradicts `roamingIndication`:'%s'",
 				string(param.SliceInfoRequestForPduSession.GetRoamingIndication()))
-			invalidParams := []models.InvalidParam{
-				{
-					Param:  "home-plmn-id",
-					Reason: openapi.PtrString(problemDetail),
-				},
-			}
+			invalidParam := models.NewInvalidParam("home-plmn-id")
+			invalidParam.SetReason(problemDetail)
+			invalidParams := []models.InvalidParam{*invalidParam}
 			*problemDetails = *utils.ProblemDetailsWithInvalidParams(util.INVALID_REQUEST, http.StatusBadRequest, problemDetail, invalidParams)
 			status = http.StatusBadRequest
 			return status
 		}
 	}
 
-	if param.Tai != nil && !util.CheckSupportedSnssaiInTa(param.SliceInfoRequestForPduSession.SNssai, *param.Tai) {
+	if param.Tai != nil && !util.CheckSupportedSnssaiInTa(param.SliceInfoRequestForPduSession.GetSNssai(), *param.Tai) {
 		// Requested S-NSSAI does not supported in UE's current TA
 		// Add it to Rejected NSSAI in TA
-		authorizedNetworkSliceInfo.RejectedNssaiInTa = append(authorizedNetworkSliceInfo.RejectedNssaiInTa, param.SliceInfoRequestForPduSession.SNssai)
+		rejectedNssaiInTa := append(authorizedNetworkSliceInfo.GetRejectedNssaiInTa(), param.SliceInfoRequestForPduSession.GetSNssai())
+		authorizedNetworkSliceInfo.SetRejectedNssaiInTa(rejectedNssaiInTa)
 		status = http.StatusOK
 		return status
 	}
 
-	nsiInformationList := util.GetNsiInformationListFromConfig(param.SliceInfoRequestForPduSession.SNssai)
+	nsiInformationList := util.GetNsiInformationListFromConfig(param.SliceInfoRequestForPduSession.GetSNssai())
 
 	if nsiInformationList != nil {
 		nsiInformation := selectNsiInformation(nsiInformationList)

--- a/producer/nsselection_for_registration.go
+++ b/producer/nsselection_for_registration.go
@@ -17,7 +17,6 @@ import (
 	"github.com/omec-project/nssf/factory"
 	"github.com/omec-project/nssf/logger"
 	"github.com/omec-project/nssf/util"
-	"github.com/omec-project/openapi/v2"
 	"github.com/omec-project/openapi/v2/models"
 	"github.com/omec-project/openapi/v2/utils"
 )
@@ -37,25 +36,25 @@ func useDefaultSubscribedSnssai(
 		}
 	}
 
-	for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.SubscribedNssai {
+	for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.GetSubscribedNssai() {
 		if subscribedSnssai.GetDefaultIndication() {
 			// Subscribed S-NSSAI is marked as default S-NSSAI
 
 			var mappingOfSubscribedSnssai models.Snssai
 			// TODO: Compared with Restricted S-NSSAI list in configuration under roaming scenario
-			if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.SubscribedSnssai) {
-				targetMapping, found := util.FindMappingWithHomeSnssai(subscribedSnssai.SubscribedSnssai, mappingOfSnssai)
+			if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.GetSubscribedSnssai()) {
+				targetMapping, found := util.FindMappingWithHomeSnssai(subscribedSnssai.GetSubscribedSnssai(), mappingOfSnssai)
 
 				if !found {
 					logger.Nsselection.Warnf("no mapping of Subscribed S-NSSAI %+v in PLMN %+v in NSSF configuration",
-						subscribedSnssai.SubscribedSnssai,
+						subscribedSnssai.GetSubscribedSnssai(),
 						*param.HomePlmnId)
 					continue
 				} else {
-					mappingOfSubscribedSnssai = targetMapping.ServingSnssai
+					mappingOfSubscribedSnssai = targetMapping.GetServingSnssai()
 				}
 			} else {
-				mappingOfSubscribedSnssai = subscribedSnssai.SubscribedSnssai
+				mappingOfSubscribedSnssai = subscribedSnssai.GetSubscribedSnssai()
 			}
 
 			if param.Tai != nil && !util.CheckSupportedSnssaiInTa(mappingOfSubscribedSnssai, *param.Tai) {
@@ -63,16 +62,15 @@ func useDefaultSubscribedSnssai(
 			}
 
 			var allowedSnssaiElement models.AllowedSnssai
-			allowedSnssaiElement.AllowedSnssai = mappingOfSubscribedSnssai
+			allowedSnssaiElement.SetAllowedSnssai(mappingOfSubscribedSnssai)
 			nsiInformationList := util.GetNsiInformationListFromConfig(mappingOfSubscribedSnssai)
 			if nsiInformationList != nil {
 				// TODO: `NsiInformationList` should be slice in `AllowedSnssai` instead of pointer of slice
 				allowedSnssaiElement.NsiInformationList = append(allowedSnssaiElement.NsiInformationList,
 					nsiInformationList...)
 			}
-			if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.SubscribedSnssai) {
-				mappedHomeSnssai := subscribedSnssai.SubscribedSnssai
-				allowedSnssaiElement.MappedHomeSnssai = &mappedHomeSnssai
+			if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.GetSubscribedSnssai()) {
+				allowedSnssaiElement.SetMappedHomeSnssai(subscribedSnssai.GetSubscribedSnssai())
 			}
 
 			// Default Access Type is set to 3GPP Access if no TAI is provided
@@ -92,7 +90,7 @@ func useDefaultSubscribedSnssai(
 func useDefaultConfiguredNssai(
 	param NsselectionQueryParameter, authorizedNetworkSliceInfo *models.AuthorizedNetworkSliceInfo,
 ) {
-	for _, requestedSnssai := range param.SliceInfoRequestForRegistration.RequestedNssai {
+	for _, requestedSnssai := range param.SliceInfoRequestForRegistration.GetRequestedNssai() {
 		// Check whether the Default Configured S-NSSAI is standard, which could be commonly decided by all roaming partners
 		if !util.CheckStandardSnssai(requestedSnssai) {
 			logger.Nsselection.Infof("s-nssai %+v in Requested NSSAI which based on Default Configured NSSAI is not standard",
@@ -101,12 +99,12 @@ func useDefaultConfiguredNssai(
 		}
 
 		// Check whether the Default Configured S-NSSAI is subscribed
-		for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.SubscribedNssai {
-			if factory.SnssaiToKey(requestedSnssai) == factory.SnssaiToKey(subscribedSnssai.SubscribedSnssai) {
-				var configuredSnssai models.ConfiguredSnssai
-				configuredSnssai.ConfiguredSnssai = requestedSnssai
+		for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.GetSubscribedNssai() {
+			if factory.SnssaiToKey(requestedSnssai) == factory.SnssaiToKey(subscribedSnssai.GetSubscribedSnssai()) {
+				configuredSnssai := models.NewConfiguredSnssaiWithDefaults()
+				configuredSnssai.SetConfiguredSnssai(requestedSnssai)
 
-				authorizedNetworkSliceInfo.ConfiguredNssai = append(authorizedNetworkSliceInfo.ConfiguredNssai, configuredSnssai)
+				authorizedNetworkSliceInfo.SetConfiguredNssai(append(authorizedNetworkSliceInfo.GetConfiguredNssai(), *configuredSnssai))
 				break
 			}
 		}
@@ -128,32 +126,31 @@ func setConfiguredNssai(
 		}
 	}
 
-	for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.SubscribedNssai {
+	for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.GetSubscribedNssai() {
 		var mappingOfSubscribedSnssai models.Snssai
-		if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.SubscribedSnssai) {
-			targetMapping, found := util.FindMappingWithHomeSnssai(subscribedSnssai.SubscribedSnssai, mappingOfSnssai)
+		if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.GetSubscribedSnssai()) {
+			targetMapping, found := util.FindMappingWithHomeSnssai(subscribedSnssai.GetSubscribedSnssai(), mappingOfSnssai)
 
 			if !found {
 				logger.Nsselection.Warnf("no mapping of Subscribed S-NSSAI %+v in PLMN %+v in NSSF configuration",
-					subscribedSnssai.SubscribedSnssai,
+					subscribedSnssai.GetSubscribedSnssai(),
 					*param.HomePlmnId)
 				continue
 			} else {
-				mappingOfSubscribedSnssai = targetMapping.ServingSnssai
+				mappingOfSubscribedSnssai = targetMapping.GetServingSnssai()
 			}
 		} else {
-			mappingOfSubscribedSnssai = subscribedSnssai.SubscribedSnssai
+			mappingOfSubscribedSnssai = subscribedSnssai.GetSubscribedSnssai()
 		}
 
-		if util.CheckSupportedSnssaiInPlmn(mappingOfSubscribedSnssai, param.Tai.PlmnId) {
-			var configuredSnssai models.ConfiguredSnssai
-			configuredSnssai.ConfiguredSnssai = mappingOfSubscribedSnssai
-			if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.SubscribedSnssai) {
-				mappedHomeSnssai := subscribedSnssai.SubscribedSnssai
-				configuredSnssai.SetMappedHomeSnssai(mappedHomeSnssai)
+		if util.CheckSupportedSnssaiInPlmn(mappingOfSubscribedSnssai, param.Tai.GetPlmnId()) {
+			configuredSnssai := models.NewConfiguredSnssaiWithDefaults()
+			configuredSnssai.SetConfiguredSnssai(mappingOfSubscribedSnssai)
+			if param.HomePlmnId != nil && !util.CheckStandardSnssai(subscribedSnssai.GetSubscribedSnssai()) {
+				configuredSnssai.SetMappedHomeSnssai(subscribedSnssai.GetSubscribedSnssai())
 			}
 
-			authorizedNetworkSliceInfo.ConfiguredNssai = append(authorizedNetworkSliceInfo.ConfiguredNssai, configuredSnssai)
+			authorizedNetworkSliceInfo.SetConfiguredNssai(append(authorizedNetworkSliceInfo.GetConfiguredNssai(), *configuredSnssai))
 		}
 	}
 }
@@ -168,7 +165,8 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 	if param.HomePlmnId != nil {
 		// Check whether UE's Home PLMN is supported when UE is a roamer
 		if !util.CheckSupportedHplmn(*param.HomePlmnId) {
-			authorizedNetworkSliceInfo.RejectedNssaiInPlmn = append(authorizedNetworkSliceInfo.RejectedNssaiInPlmn, param.SliceInfoRequestForRegistration.RequestedNssai...)
+			rejectedNssaiInPlmn := append(authorizedNetworkSliceInfo.GetRejectedNssaiInPlmn(), param.SliceInfoRequestForRegistration.GetRequestedNssai()...)
+			authorizedNetworkSliceInfo.SetRejectedNssaiInPlmn(rejectedNssaiInPlmn)
 
 			status = http.StatusOK
 			return status
@@ -178,7 +176,8 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 	if param.Tai != nil {
 		// Check whether UE's current TA is supported when UE provides TAI
 		if !util.CheckSupportedTa(*param.Tai) {
-			authorizedNetworkSliceInfo.RejectedNssaiInTa = append(authorizedNetworkSliceInfo.RejectedNssaiInTa, param.SliceInfoRequestForRegistration.RequestedNssai...)
+			rejectedNssaiInTa := append(authorizedNetworkSliceInfo.GetRejectedNssaiInTa(), param.SliceInfoRequestForRegistration.GetRequestedNssai()...)
+			authorizedNetworkSliceInfo.SetRejectedNssaiInTa(rejectedNssaiInTa)
 
 			status = http.StatusOK
 			return status
@@ -193,12 +192,9 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 
 		if param.HomePlmnId == nil {
 			problemDetail := "[Query Parameter] `home-plmn-id` should be provided when requesting VPLMN specific mapped S-NSSAI values"
-			invalidParams := []models.InvalidParam{
-				{
-					Param:  "home-plmn-id",
-					Reason: openapi.PtrString(problemDetail),
-				},
-			}
+			invalidParam := models.NewInvalidParam("home-plmn-id")
+			invalidParam.SetReason(problemDetail)
+			invalidParams := []models.InvalidParam{*invalidParam}
 			*problemDetails = *utils.ProblemDetailsWithInvalidParams(util.INVALID_REQUEST, http.StatusBadRequest, problemDetail, invalidParams)
 			status = http.StatusBadRequest
 			return status
@@ -208,23 +204,23 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 
 		if mappingOfSnssai != nil {
 			// Find mappings for S-NSSAIs in `subscribedSnssai`
-			for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.SubscribedNssai {
-				if util.CheckStandardSnssai(subscribedSnssai.SubscribedSnssai) {
+			for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.GetSubscribedNssai() {
+				if util.CheckStandardSnssai(subscribedSnssai.GetSubscribedSnssai()) {
 					continue
 				}
 
-				targetMapping, found := util.FindMappingWithHomeSnssai(subscribedSnssai.SubscribedSnssai, mappingOfSnssai)
+				targetMapping, found := util.FindMappingWithHomeSnssai(subscribedSnssai.GetSubscribedSnssai(), mappingOfSnssai)
 
 				if !found {
 					logger.Nsselection.Warnf("no mapping of Subscribed S-NSSAI %+v in PLMN %+v in NSSF configuration",
-						subscribedSnssai.SubscribedSnssai,
+						subscribedSnssai.GetSubscribedSnssai(),
 						*param.HomePlmnId)
 					continue
 				} else {
 					// Add mappings to Allowed NSSAI list
 					var allowedSnssaiElement models.AllowedSnssai
-					allowedSnssaiElement.AllowedSnssai = targetMapping.ServingSnssai
-					mappedHomeSnssai := subscribedSnssai.SubscribedSnssai
+					allowedSnssaiElement.AllowedSnssai = targetMapping.GetServingSnssai()
+					mappedHomeSnssai := subscribedSnssai.GetSubscribedSnssai()
 					allowedSnssaiElement.MappedHomeSnssai = &mappedHomeSnssai
 
 					// Default Access Type is set to 3GPP Access if no TAI is provided
@@ -240,7 +236,7 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 			}
 
 			// Find mappings for S-NSSAIs in `sNssaiForMapping`
-			for _, snssai := range param.SliceInfoRequestForRegistration.SNssaiForMapping {
+			for _, snssai := range param.SliceInfoRequestForRegistration.GetSNssaiForMapping() {
 				if util.CheckStandardSnssai(snssai) {
 					continue
 				}
@@ -255,7 +251,7 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 				} else {
 					// Add mappings to Allowed NSSAI list
 					var allowedSnssaiElement models.AllowedSnssai
-					allowedSnssaiElement.AllowedSnssai = targetMapping.ServingSnssai
+					allowedSnssaiElement.AllowedSnssai = targetMapping.GetServingSnssai()
 					snssaiCopy := snssai
 					allowedSnssaiElement.MappedHomeSnssai = &snssaiCopy
 
@@ -282,12 +278,12 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 	}
 
 	checkInvalidRequestedNssai := false
-	if len(param.SliceInfoRequestForRegistration.RequestedNssai) != 0 {
+	if len(param.SliceInfoRequestForRegistration.GetRequestedNssai()) != 0 {
 		// Requested NSSAI is provided
 		// Verify which S-NSSAI(s) in the Requested NSSAI are permitted based on comparing the Subscribed S-NSSAI(s)
 
 		if param.Tai != nil &&
-			!util.CheckSupportedNssaiInPlmn(param.SliceInfoRequestForRegistration.RequestedNssai, param.Tai.PlmnId) {
+			!util.CheckSupportedNssaiInPlmn(param.SliceInfoRequestForRegistration.GetRequestedNssai(), param.Tai.GetPlmnId()) {
 			// Return ProblemDetails indicating S-NSSAI is not supported
 			// TODO: Based on TS 23.501 V15.2.0, if the Requested NSSAI includes an S-NSSAI that is not valid in the
 			//       Serving PLMN, the NSSF may derive the Configured NSSAI for Serving PLMN
@@ -304,11 +300,12 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 		// Check if any Requested S-NSSAIs is present in Subscribed S-NSSAIs
 		checkIfRequestAllowed := false
 
-		for _, requestedSnssai := range param.SliceInfoRequestForRegistration.RequestedNssai {
+		for _, requestedSnssai := range param.SliceInfoRequestForRegistration.GetRequestedNssai() {
 			if param.Tai != nil && !util.CheckSupportedSnssaiInTa(requestedSnssai, *param.Tai) {
 				// Requested S-NSSAI does not supported in UE's current TA
 				// Add it to Rejected NSSAI in TA
-				authorizedNetworkSliceInfo.RejectedNssaiInTa = append(authorizedNetworkSliceInfo.RejectedNssaiInTa, requestedSnssai)
+				rejectedNssaiInTa := append(authorizedNetworkSliceInfo.GetRejectedNssaiInTa(), requestedSnssai)
+				authorizedNetworkSliceInfo.SetRejectedNssaiInTa(rejectedNssaiInTa)
 				continue
 			}
 
@@ -318,27 +315,28 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 				// Standard S-NSSAIs are supported to be commonly decided by all roaming partners
 				// Only non-standard S-NSSAIs are required to find mappings
 				targetMapping, found := util.FindMappingWithServingSnssai(requestedSnssai,
-					param.SliceInfoRequestForRegistration.MappingOfNssai)
+					param.SliceInfoRequestForRegistration.GetMappingOfNssai())
 
 				if !found {
 					// No mapping of Requested S-NSSAI to HPLMN S-NSSAI is provided by UE
 					// TODO: Search for local configuration if there is no provided mapping from UE, and update UE's
 					//       Configured NSSAI
 					checkInvalidRequestedNssai = true
-					authorizedNetworkSliceInfo.RejectedNssaiInPlmn = append(authorizedNetworkSliceInfo.RejectedNssaiInPlmn, requestedSnssai)
+					rejectedNssaiInPlmn := append(authorizedNetworkSliceInfo.GetRejectedNssaiInPlmn(), requestedSnssai)
+					authorizedNetworkSliceInfo.SetRejectedNssaiInPlmn(rejectedNssaiInPlmn)
 					continue
 				} else {
 					// TODO: Check if mappings of S-NSSAIs are correct
 					//       If not, update UE's Configured NSSAI
-					mappingOfRequestedSnssai = targetMapping.HomeSnssai
+					mappingOfRequestedSnssai = targetMapping.GetHomeSnssai()
 				}
 			} else {
 				mappingOfRequestedSnssai = requestedSnssai
 			}
 
 			hitSubscription := false
-			for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.SubscribedNssai {
-				if factory.SnssaiToKey(mappingOfRequestedSnssai) == factory.SnssaiToKey(subscribedSnssai.SubscribedSnssai) {
+			for _, subscribedSnssai := range param.SliceInfoRequestForRegistration.GetSubscribedNssai() {
+				if factory.SnssaiToKey(mappingOfRequestedSnssai) == factory.SnssaiToKey(subscribedSnssai.GetSubscribedSnssai()) {
 					// Requested S-NSSAI matches one of Subscribed S-NSSAI
 					// Add it to Allowed NSSAI list
 					hitSubscription = true
@@ -352,7 +350,7 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 							nsiInformationList...)
 					}
 					if param.HomePlmnId != nil && !util.CheckStandardSnssai(requestedSnssai) {
-						mappedHomeSnssai := subscribedSnssai.SubscribedSnssai
+						mappedHomeSnssai := subscribedSnssai.GetSubscribedSnssai()
 						allowedSnssaiElement.MappedHomeSnssai = &mappedHomeSnssai
 					}
 
@@ -375,7 +373,8 @@ func nsselectionForRegistration(param NsselectionQueryParameter,
 				// Requested S-NSSAI does not match any Subscribed S-NSSAI
 				// Add it to Rejected NSSAI in PLMN
 				checkInvalidRequestedNssai = true
-				authorizedNetworkSliceInfo.RejectedNssaiInPlmn = append(authorizedNetworkSliceInfo.RejectedNssaiInPlmn, requestedSnssai)
+				rejectedNssaiInPlmn := append(authorizedNetworkSliceInfo.GetRejectedNssaiInPlmn(), requestedSnssai)
+				authorizedNetworkSliceInfo.SetRejectedNssaiInPlmn(rejectedNssaiInPlmn)
 			}
 		}
 


### PR DESCRIPTION
Also, improve logic to parse `sst` and skip `sd` (fail) when `sst` is not present